### PR TITLE
Allow turning off default metrics collection

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,8 +50,10 @@ class APM {
         // prometheus stuff
         // --------------------------------------------------------------
         this.config.NORMALIZE_ENDPOINT = this.config.NORMALIZE_ENDPOINT === undefined ? true : this.config.NORMALIZE_ENDPOINT
-        const collectDefaultMetrics = this.client.collectDefaultMetrics
-        collectDefaultMetrics(this.config.PROM_CLIENT_CONF)
+        if ([1, true, 'true', 'on', 'yes', undefined].indexOf(this.config.COLLECT_DEFAULT_METRICS) >= 0 ) {
+            const collectDefaultMetrics = this.client.collectDefaultMetrics
+            collectDefaultMetrics(this.config.PROM_CLIENT_CONF)
+        }
         this.server = http.createServer(requestListener)
         this.server.listen(this.config.PORT || 9350)
     }

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -1,11 +1,25 @@
 const APM = require('../index')
 
-describe('retry', () => {
+describe('prom-client integration', () => {
     let apm
 
-    afterAll(() => {
+    afterEach(() => {
         apm.destroy()
     })
+
+    it('should report metrics by default', async () => {
+        apm = new APM()
+        apm.init()
+        const data = await apm.client.register.metrics()
+        expect(data.includes("process_cpu_user_seconds_total")).toEqual(true)
+    });
+
+    it('should support turning off default collection', async () => {
+        apm = new APM({ COLLECT_DEFAULT_METRICS: false })
+        apm.init()
+        const data = await apm.client.register.metrics()
+        expect(data.includes("process_cpu_user_seconds_total")).toEqual(false)
+    });
 
     it('should use custom config for prom', async () => {
         apm = new APM({


### PR DESCRIPTION
I'm writing a load test and I'm thus concerned about the latency and resource utilization of the node process running the load test. Thus, I would like to be able to turn off collecting default node metrics. This PR retains the current default of collecting node metrics, but allows setting `COLLECT_DEFAULT_METRICS` to `false` and thus skip the call to prom-client's `collectDefaultMetrics()` initializer.